### PR TITLE
Use credentials for downloading files

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -78,6 +78,7 @@ if [[ ${http_code} -eq '200' ]]; then
     echo "Downloading ${file_name}"
     curl \
       -k \
+      -H "X-JFrog-Art-Api:${api_key}" \
       -o "${1}/${file_name}" \
       --silent \
       "${host}/${repository_id}/$(echo ${req_files} | jq -r ".results[${i}]|\"\(.path)/\(.name)\"")"


### PR DESCRIPTION
Right now, when downloading files, all files contain :

```plaintext
{
  "errors" : [ {
    "status" : 401,
    "message" : "Authentication is required"
  } ]
}
```

Using credentials to download files might help this situation.