### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Download the artifacts of the given ref to the destination. It will return the s
 
 #### Parameters
 
-- `qualifiers`: *Optional.* The artifacts classifiers ex: [source,javadoc]. If specified, the resource will only retreive the qualified artifacts.
+- `qualifiers`: *Optional.* The artifacts classifiers ex: [source,javadoc]. If specified, the resource will retreive artifacts with no qualifier plus the qualified artifacts. By default, when no qualifiers are specified, only artifacts with no qualifiers and the version are retreived.
 
 ### `out`: Push the artifacts to the repository
 


### PR DESCRIPTION
I've modified the document behavior of the qualifier based on what we have observed. 
Technically, if we have artifacts named: `<artifact-name>-<version>.<ex>t` and other artifacts with qualifers named`<artifact-name>-<version>-<qualifier>.<ext>`, if we don't document the qualifiers field, only the artifact without qualifier (plus the version) is retreived, while when adding a list of qualifiers, only artifacts without qualifier plus artificats with one of the specified qualifiers are retreived.